### PR TITLE
Add support for UIDocumentBrowserViewController and Open in Place

### DIFF
--- a/KeePassLib/KdbPassword.h
+++ b/KeePassLib/KdbPassword.h
@@ -12,7 +12,7 @@
 
 - (id)initWithPassword:(NSString*)inPassword
       passwordEncoding:(NSStringEncoding)inPasswordEncoding
-               keyFile:(NSString*)inKeyFile;
+               keyFile:(NSURL*)inKeyFile;
 
 - (NSData*)createFinalKeyForVersion:(uint8_t)version
                          masterSeed:(NSData*)masterSeed

--- a/MiniKeePass/AppDelegate.m
+++ b/MiniKeePass/AppDelegate.m
@@ -23,21 +23,10 @@
 #import "LockScreenManager.h"
 #import "MiniKeePass-Swift.h"
 
-@interface AppDelegate ()
-
-@property (nonatomic, strong) FilesViewController *filesViewController;;
-@property (nonatomic, strong) UINavigationController *navigationController;
-
-@end
-
 @implementation AppDelegate
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     _databaseDocument = nil;
-    
-    // Store references to base view controllers
-    self.navigationController = (UINavigationController *) self.window.rootViewController;
-    self.filesViewController = (FilesViewController *) self.navigationController.topViewController;
     
     // Add a pasteboard notification listener to support clearing the clipboard
     NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
@@ -111,9 +100,6 @@
 
     // Delete the Inbox folder if it exists
     [fileManager removeItemAtPath:[documentsDirectory stringByAppendingPathComponent:@"Inbox"] error:nil];
-
-    [self.filesViewController updateFiles];
-    [self.filesViewController.tableView reloadData];
 }
 
 - (void)setDatabaseDocument:(DatabaseDocument *)newDatabaseDocument {
@@ -122,17 +108,21 @@
     }
     
     _databaseDocument = newDatabaseDocument;
-    
-    UINavigationController *navController = (UINavigationController *)self.window.rootViewController;
-    FilesViewController * filesViewController = navController.viewControllers.firstObject;
-    
-    [filesViewController performSegueWithIdentifier:@"fileOpened" sender:self];
+
+    UIStoryboard *mainStoryboard = [UIStoryboard storyboardWithName:@"Main" bundle:nil];
+    UINavigationController *navController = (UINavigationController *)[mainStoryboard instantiateViewControllerWithIdentifier:@"OpenDatabase"];
+    GroupViewController *groupViewController = (GroupViewController *)navController.viewControllers.firstObject;
+
+    groupViewController.parentGroup = _databaseDocument.kdbTree.root;
+    groupViewController.title = [[NSURL fileURLWithPath:_databaseDocument.filename] lastPathComponent];
+
+    [self.window.rootViewController presentViewController:navController animated:YES completion:nil];
 }
 
 - (void)closeDatabase {
     // Close any open database views
-    [self.navigationController popToRootViewControllerAnimated:NO];
-    
+    [self.window.rootViewController dismissViewControllerAnimated:YES completion:nil];
+
     _databaseDocument = nil;
 }
 

--- a/MiniKeePass/DatabaseDocument.h
+++ b/MiniKeePass/DatabaseDocument.h
@@ -28,7 +28,7 @@
 /// @param password Database password
 /// @param keyFile Path to KeyFile
 /// @return A KeePass DatabaseDocument
-- (id)initWithURL:(NSURL *)url password:(NSString *)password keyFile:(NSString *)keyFile;
+- (id)initWithURL:(NSURL *)url password:(NSString *)password keyFile:(NSURL *)keyFile;
 
 /// Save the current KeePass DatabaseDocument
 - (void)save;

--- a/MiniKeePass/DatabaseDocument.h
+++ b/MiniKeePass/DatabaseDocument.h
@@ -15,10 +15,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#import <Foundation/Foundation.h>
+@import UIKit;
 #import "KdbLib.h"
 
-@interface DatabaseDocument : NSObject
+@interface DatabaseDocument : UIDocument
 
 @property (nonatomic, strong) KdbTree *kdbTree;
 @property (nonatomic, copy) NSString *filename;
@@ -28,7 +28,7 @@
 /// @param password Database password
 /// @param keyFile Path to KeyFile
 /// @return A KeePass DatabaseDocument
-- (id)initWithFilename:(NSString *)filename password:(NSString *)password keyFile:(NSString *)keyFile;
+- (id)initWithURL:(NSURL *)url password:(NSString *)password keyFile:(NSString *)keyFile;
 
 /// Save the current KeePass DatabaseDocument
 - (void)save;

--- a/MiniKeePass/DatabaseDocument.m
+++ b/MiniKeePass/DatabaseDocument.m
@@ -24,7 +24,7 @@
 
 @implementation DatabaseDocument
 
-- (id)initWithURL:(NSURL *)url password:(NSString *)password keyFile:(NSString *)keyFile {
+- (id)initWithURL:(NSURL *)url password:(NSString *)password keyFile:(NSURL *)keyFile {
     self = [super initWithFileURL:url];
     if (self) {
         if (password == nil && keyFile == nil) {

--- a/MiniKeePass/DatabaseDocument.m
+++ b/MiniKeePass/DatabaseDocument.m
@@ -24,8 +24,8 @@
 
 @implementation DatabaseDocument
 
-- (id)initWithFilename:(NSString *)filename password:(NSString *)password keyFile:(NSString *)keyFile {
-    self = [super init];
+- (id)initWithURL:(NSURL *)url password:(NSString *)password keyFile:(NSString *)keyFile {
+    self = [super initWithFileURL:url];
     if (self) {
         if (password == nil && keyFile == nil) {
             @throw [NSException exceptionWithName:@"IllegalArgument"
@@ -33,14 +33,14 @@
                                          userInfo:nil];
         }
 
-        self.filename = filename;
+        self.filename = url.lastPathComponent;
 
         NSStringEncoding passwordEncoding = [[AppSettings sharedInstance] passwordEncoding];
         self.kdbPassword = [[KdbPassword alloc] initWithPassword:password
                                                 passwordEncoding:passwordEncoding
                                                          keyFile:keyFile];
 
-        self.kdbTree = [KdbReaderFactory load:self.filename withPassword:self.kdbPassword];
+        self.kdbTree = [KdbReaderFactory load:url.path withPassword:self.kdbPassword];
     }
     return self;
 }

--- a/MiniKeePass/DatabaseManager.h
+++ b/MiniKeePass/DatabaseManager.h
@@ -20,22 +20,16 @@
 @interface DatabaseManager : NSObject
 
 /// A string containing the name of the KeePass DatabaseDocument to be managed
-@property (nonatomic, copy) NSString *selectedFilename;
+@property (nonatomic, copy) NSURL *selectedURL;
 
 /// Create a DatabaseManager instance
 + (DatabaseManager*)sharedInstance;
 
-- (NSArray *)getDatabases;
-- (NSArray *)getKeyFiles;
-- (NSURL *)getFileUrl:(NSString *)filename;
-- (NSDate *)getFileLastModificationDate:(NSURL *)url;
-- (void)deleteFile:(NSString *)filename;
 - (void)newDatabase:(NSURL *)url password:(NSString *)password version:(NSInteger)version;
-- (void)renameDatabase:(NSURL *)originalUrl newUrl:(NSURL *)newUrl;
 
 /// Open the specified KeePass DatabaseDocument
 /// @param path Path to the chosen KeePass DatabaseDocument
 /// @param animated Animate the ViewController transition
-- (void)openDatabaseDocument:(NSString*)path animated:(BOOL)newAnimated;
+- (void)openDatabaseDocument:(NSURL *)documentURL animated:(BOOL)newAnimated;
 
 @end

--- a/MiniKeePass/DatabaseManager.m
+++ b/MiniKeePass/DatabaseManager.m
@@ -121,7 +121,7 @@ static DatabaseManager *sharedInstance;
     // Load the database
     @try {
         // Open the database
-        DatabaseDocument *dd = [[DatabaseDocument alloc] initWithURL:self.selectedURL password:password keyFile:keyFilePath];
+        DatabaseDocument *dd = [[DatabaseDocument alloc] initWithURL:self.selectedURL password:password keyFile:passwordEntryViewController.keyFile];
 
         // Store the password in the keychain
         if ([[AppSettings sharedInstance] rememberPasswordsEnabled]) {

--- a/MiniKeePass/Files View/FilesViewController.swift
+++ b/MiniKeePass/Files View/FilesViewController.swift
@@ -17,234 +17,70 @@
 
 import UIKit
 
-class FilesViewController: UITableViewController, NewDatabaseDelegate {
-    private let databaseReuseIdentifier = "DatabaseCell"
-    private let keyFileReuseIdentifier = "KeyFileCell"
+class FilesViewController: UIDocumentBrowserViewController, UIDocumentBrowserViewControllerDelegate {
+    var importHandler: ((URL?, UIDocumentBrowserViewController.ImportMode) -> Void)?
 
-    private enum Section : Int {
-        case databases = 0
-        case keyFiles = 1
 
-        static let AllValues = [Section.databases, Section.keyFiles]
-    }
-
-    var databaseFiles: [String] = []
-    var keyFiles: [String] = []
-    
     override func viewDidLoad() {
         super.viewDidLoad();
-        self.navigationItem.rightBarButtonItem = self.editButtonItem
-    }
-    
-    override func viewWillAppear(_ animated: Bool) {
-        updateFiles();
-        super.viewWillAppear(animated)
-    }
-    
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        switch segue.identifier {
-        case "newDatabase"?:
-            guard let navigationController = segue.destination as? UINavigationController,
-                let newDatabaseViewController = navigationController.topViewController as? NewDatabaseViewController else {
-                    return
-            }
 
-            newDatabaseViewController.delegate = self
-        case "fileOpened"?:
-            guard let groupViewController = segue.destination as? GroupViewController else {
+        delegate = self
+
+        allowsDocumentCreation = true
+        allowsPickingMultipleItems = false
+    }
+
+    // MARK: UIDocumentBrowserViewControllerDelegate
+
+    func documentBrowser(_ controller: UIDocumentBrowserViewController, didRequestDocumentCreationWithHandler importHandler: @escaping (URL?, UIDocumentBrowserViewController.ImportMode) -> Void) {
+        let newDocumentURL: URL? = nil
+
+        let storyboard = UIStoryboard(name: "NewDatabase", bundle: nil)
+        guard let navController = storyboard.instantiateInitialViewController() as? UINavigationController,
+            let newDatabaseViewController = navController.viewControllers.first as? NewDatabaseViewController else {
+                importHandler(nil, .none)
                 return
-            }
-
-            let appDelegate = AppDelegate.getDelegate()
-            let document = appDelegate?.databaseDocument
-            
-            groupViewController.parentGroup = document?.kdbTree.root
-            groupViewController.title = URL(fileURLWithPath: document!.filename).lastPathComponent
-        default:
-            break
-        }
-    }
-    
-    @objc func updateFiles() {
-        if let databaseManager = DatabaseManager.sharedInstance() {
-            databaseFiles = databaseManager.getDatabases() as! [String]
-            keyFiles = databaseManager.getKeyFiles() as! [String]
-        }
-    }
-    
-    // MARK: - Empty State
-
-    func toggleEmptyState() {
-        if (databaseFiles.count == 0 && keyFiles.count == 0) {
-            let emptyStateLabel = UILabel()
-            emptyStateLabel.text = NSLocalizedString("Tap the + button to add a new KeePass file.", comment: "")
-            emptyStateLabel.textAlignment = .center
-            emptyStateLabel.textColor = UIColor.systemGray
-            emptyStateLabel.numberOfLines = 0
-            emptyStateLabel.lineBreakMode = .byWordWrapping
-
-            tableView.backgroundView = emptyStateLabel
-            tableView.separatorStyle = .none
-        } else {
-            tableView.backgroundView = nil
-            tableView.separatorStyle = .singleLine
-        }
-    }
-
-    // MARK: - UITableView data source
-
-    override func numberOfSections(in tableView: UITableView) -> Int {
-        return Section.AllValues.count
-    }
-
-    override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-        switch Section.AllValues[section] {
-        case .databases:
-            return NSLocalizedString("Databases", comment: "")
-        case .keyFiles:
-            return NSLocalizedString("Key Files", comment: "")
-        }
-    }
-
-    override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        // Hide the section titles if there are no files in a section
-        switch Section.AllValues[section] {
-        case .databases:
-            if (databaseFiles.count == 0) {
-                return 0
-            }
-        case .keyFiles:
-            if (keyFiles.count == 0) {
-                return 0
-            }
         }
 
-        return UITableView.automaticDimension
+        newDatabaseViewController.delegate = self
+        self.importHandler = importHandler
+        present(navController, animated: true, completion: nil)
     }
 
-    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        toggleEmptyState()
+    func documentBrowser(_ controller: UIDocumentBrowserViewController, didPickDocumentsAt documentURLs: [URL]) {
+        guard let sourceURL = documentURLs.first else { return }
 
-        switch Section.AllValues[section] {
-        case .databases:
-            return databaseFiles.count
-        case .keyFiles:
-            return keyFiles.count
-        }
+        // Present the Document View Controller for the first document that was picked.
+        // If you support picking multiple items, make sure you handle them all.
+        presentDocument(at: sourceURL)
     }
 
-    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell: UITableViewCell
-        let filename: String
+    func documentBrowser(_ controller: UIDocumentBrowserViewController, didImportDocumentAt sourceURL: URL, toDestinationURL destinationURL: URL) {
+        // Present the Document View Controller for the new newly created document
+        presentDocument(at: destinationURL)
+    }
 
-        // Get the cell and filename
-        switch Section.AllValues[indexPath.section] {
-        case .databases:
-            cell = tableView.dequeueReusableCell(withIdentifier: databaseReuseIdentifier, for: indexPath)
-            filename = databaseFiles[indexPath.row]
-        case .keyFiles:
-            cell = tableView.dequeueReusableCell(withIdentifier: keyFileReuseIdentifier, for: indexPath)
-            filename = keyFiles[indexPath.row]
-        }
+    func documentBrowser(_ controller: UIDocumentBrowserViewController, failedToImportDocumentAt documentURL: URL, error: Error?) {
+        // Make sure to handle the failed import appropriately, e.g., by presenting an error message to the user.
+    }
 
-        cell.textLabel!.text = filename
+    // MARK: Document Presentation
 
-        // Get the file's last modification time
+    func presentDocument(at documentURL: URL) {
         let databaseManager = DatabaseManager.sharedInstance()
-        let url = databaseManager?.getFileUrl(filename)
-        let date = databaseManager?.getFileLastModificationDate(url)
-
-        // Format the last modified time as the subtitle of the cell
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateStyle = .short
-        dateFormatter.timeStyle = .short
-        cell.detailTextLabel!.text = NSLocalizedString("Last Modified", comment: "") + ": " + dateFormatter.string(from: date!)
-
-        return cell
+        databaseManager?.openDatabaseDocument(documentURL, animated: true)
     }
+}
 
-    // MARK: - UITableView delegate
+// MARK: NewDatabaseDelegate
 
-    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        // Load the database
-        let databaseManager = DatabaseManager.sharedInstance()
-        databaseManager?.openDatabaseDocument(databaseFiles[indexPath.row], animated: true)
-    }
-
-    override func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
-        let deleteAction = UIContextualAction(style: .destructive,
-                                              title: NSLocalizedString("Delete", comment: "")) { (_, _, completion) in
-                                                self.deleteRowAtIndexPath(indexPath)
-                                                completion(true)
+extension FilesViewController: NewDatabaseDelegate {
+    func newDatabaseCreated(url: URL?) {
+        guard let successfulURL = url else {
+            importHandler?(nil, .none)
+            return
         }
 
-        let renameAction = UIContextualAction(style: .normal,
-                                              title: NSLocalizedString("Rename", comment: "")) { (_, _, completion) in
-                                                self.renameRowAtIndexPath(indexPath)
-                                                completion(true)
-        }
-        switch Section.AllValues[indexPath.section] {
-        case .databases:
-            return UISwipeActionsConfiguration(actions: [deleteAction, renameAction])
-        case .keyFiles:
-            return UISwipeActionsConfiguration(actions: [deleteAction])
-        }
-    }
-    
-    func renameRowAtIndexPath(_ indexPath: IndexPath) {
-        let storyboard = UIStoryboard(name: "RenameDatabase", bundle: nil)
-        let navigationController = storyboard.instantiateInitialViewController() as! UINavigationController
-        
-        let viewController = navigationController.topViewController as! RenameDatabaseViewController
-        viewController.donePressed = { (renameDatabaseViewController: RenameDatabaseViewController, originalUrl: URL, newUrl: URL) in
-            let databaseManager = DatabaseManager.sharedInstance()
-            databaseManager?.renameDatabase(originalUrl, newUrl: newUrl)
-            
-            // Update the filename in the files list
-            self.databaseFiles[indexPath.row] = newUrl.lastPathComponent
-            self.tableView.reloadRows(at: [indexPath], with: .fade)
-            
-            self.dismiss(animated: true, completion: nil)
-        }
-        
-        let databaseManager = DatabaseManager.sharedInstance()
-        viewController.originalUrl = databaseManager?.getFileUrl(databaseFiles[indexPath.row])
-        
-        present(navigationController, animated: true, completion: nil)
-    }
-    
-    func deleteRowAtIndexPath(_ indexPath: IndexPath) {
-        // Get the filename to delete
-        let filename: String
-        switch Section.AllValues[indexPath.section] {
-        case .databases:
-            filename = databaseFiles.remove(at: indexPath.row)
-        case .keyFiles:
-            filename = keyFiles.remove(at: indexPath.row)
-        }
-        
-        // Delete the file
-        let databaseManager = DatabaseManager.sharedInstance()
-        databaseManager?.deleteFile(filename)
-        
-        // Update the table
-        tableView.deleteRows(at: [indexPath], with: .fade)
-    }
-    
-    func newDatabaseCreated(filename: String) {
-        let index = self.databaseFiles.insertionIndexOf(filename) {
-            $0.localizedCaseInsensitiveCompare($1) == ComparisonResult.orderedAscending
-        }
-        self.databaseFiles.insert(filename, at: index)
-        
-        // Notify the table of the new row
-        if (self.databaseFiles.count == 1) {
-            // Reload the section if it was previously empty
-            let indexSet = IndexSet(integer: Section.databases.rawValue)
-            self.tableView.reloadSections(indexSet, with: .right)
-        } else {
-            let indexPath = IndexPath(row: index, section: Section.databases.rawValue)
-            self.tableView.insertRows(at: [indexPath], with: .right)
-        }
+        importHandler?(successfulURL, .move)
     }
 }

--- a/MiniKeePass/Group View/GroupViewController.swift
+++ b/MiniKeePass/Group View/GroupViewController.swift
@@ -55,7 +55,7 @@ class GroupViewController: UITableViewController, UISearchResultsUpdating {
     private var searchController: UISearchController?
     private var searchResults: [KdbEntry] = []
 
-    var parentGroup: KdbGroup! {
+    @objc var parentGroup: KdbGroup! {
         didSet {
             updateViewModel()
         }
@@ -66,6 +66,7 @@ class GroupViewController: UITableViewController, UISearchResultsUpdating {
 
         // Add the edit button
         navigationItem.rightBarButtonItems = [self.editButtonItem]
+        navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: AppDelegate.getDelegate(), action: #selector(AppDelegate.closeDatabase))
         if #available(iOS 11.0, *) {
             self.navigationItem.largeTitleDisplayMode = .never
         }

--- a/MiniKeePass/Main.storyboard
+++ b/MiniKeePass/Main.storyboard
@@ -1,106 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="APd-hG-9Gf">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="TtK-ae-EWl">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--Files-->
-        <scene sceneID="ire-US-7pO">
-            <objects>
-                <tableViewController title="Files" id="gkV-37-I3l" customClass="FilesViewController" customModule="MiniKeePass" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="kb0-5h-iCx">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                        <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="DatabaseCell" textLabel="AUH-xp-5SC" detailTextLabel="THz-dz-dy3" style="IBUITableViewCellStyleSubtitle" id="CNc-UM-igV">
-                                <rect key="frame" x="0.0" y="28" width="375" height="44"/>
-                                <autoresizingMask key="autoresizingMask"/>
-                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="CNc-UM-igV" id="pIV-Jf-g3j">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
-                                    <autoresizingMask key="autoresizingMask"/>
-                                    <subviews>
-                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="AUH-xp-5SC">
-                                            <rect key="frame" x="16" y="6" width="31.5" height="19.5"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
-                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Subtitle" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="THz-dz-dy3">
-                                            <rect key="frame" x="16" y="25.5" width="40.5" height="13.5"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="11"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
-                                    </subviews>
-                                </tableViewCellContentView>
-                            </tableViewCell>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="KeyFileCell" textLabel="byO-Bx-T6q" detailTextLabel="Myf-UY-krA" style="IBUITableViewCellStyleSubtitle" id="Z35-JL-jQF">
-                                <rect key="frame" x="0.0" y="72" width="375" height="44"/>
-                                <autoresizingMask key="autoresizingMask"/>
-                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Z35-JL-jQF" id="aca-vp-sAp">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
-                                    <autoresizingMask key="autoresizingMask"/>
-                                    <subviews>
-                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="byO-Bx-T6q">
-                                            <rect key="frame" x="16" y="6" width="31.5" height="19.5"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                            <color key="textColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
-                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Subtitle" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Myf-UY-krA">
-                                            <rect key="frame" x="16" y="25.5" width="40.5" height="13.5"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="11"/>
-                                            <color key="textColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
-                                    </subviews>
-                                </tableViewCellContentView>
-                            </tableViewCell>
-                        </prototypes>
-                        <connections>
-                            <outlet property="dataSource" destination="gkV-37-I3l" id="6oM-Ek-3vh"/>
-                            <outlet property="delegate" destination="gkV-37-I3l" id="u6V-Mv-DKP"/>
-                        </connections>
-                    </tableView>
-                    <toolbarItems>
-                        <barButtonItem image="gear" id="eEi-Us-9fq" userLabel="Settings Button">
-                            <connections>
-                                <segue destination="otg-5C-dk1" kind="presentation" id="qGO-S6-Vbn"/>
-                            </connections>
-                        </barButtonItem>
-                        <barButtonItem style="plain" systemItem="flexibleSpace" id="NdI-tc-oN0"/>
-                        <barButtonItem image="help" id="bhy-mg-Lcu" userLabel="Help Button">
-                            <connections>
-                                <segue destination="ddi-ko-qjw" kind="presentation" id="7fP-Rr-thn"/>
-                            </connections>
-                        </barButtonItem>
-                        <barButtonItem style="plain" systemItem="flexibleSpace" id="Rxy-Fo-qMI"/>
-                        <barButtonItem systemItem="add" id="Nee-V5-pSX" userLabel="Add Button">
-                            <connections>
-                                <segue destination="oBO-SS-Gd5" kind="presentation" identifier="newDatabase" id="jq5-Dx-yQn"/>
-                            </connections>
-                        </barButtonItem>
-                    </toolbarItems>
-                    <connections>
-                        <segue destination="I0k-i1-GRC" kind="show" identifier="fileOpened" id="Kfq-fd-iAW"/>
-                    </connections>
-                </tableViewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="i9L-8T-cQV" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="1106" y="349"/>
-        </scene>
         <!--Settings-->
         <scene sceneID="fYD-Xm-bAJ">
             <objects>
                 <viewControllerPlaceholder storyboardName="Settings" id="otg-5C-dk1" sceneMemberID="viewController"/>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="OwQ-ja-bl4" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="871" y="816"/>
+            <point key="canvasLocation" x="1702" y="815"/>
         </scene>
         <!--Help-->
         <scene sceneID="OfU-n4-Jiq">
@@ -108,7 +20,7 @@
                 <viewControllerPlaceholder storyboardName="Help" id="ddi-ko-qjw" sceneMemberID="viewController"/>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="FdI-Yc-9ji" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1106" y="816"/>
+            <point key="canvasLocation" x="1814" y="769"/>
         </scene>
         <!--NewDatabase-->
         <scene sceneID="cSf-QN-19q">
@@ -116,7 +28,7 @@
                 <viewControllerPlaceholder storyboardName="NewDatabase" id="oBO-SS-Gd5" sceneMemberID="viewController"/>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="vCb-Iy-Uev" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1314" y="816"/>
+            <point key="canvasLocation" x="1950" y="816"/>
         </scene>
         <!--Group-->
         <scene sceneID="5Ug-dB-CLJ">
@@ -170,6 +82,17 @@
                             <outlet property="delegate" destination="I0k-i1-GRC" id="f6I-8D-P81"/>
                         </connections>
                     </tableView>
+                    <toolbarItems>
+                        <barButtonItem image="gear" id="eEi-Us-9fq" userLabel="Settings Button">
+                            <connections>
+                                <segue destination="otg-5C-dk1" kind="presentation" id="9gr-BU-2qd"/>
+                            </connections>
+                        </barButtonItem>
+                        <barButtonItem style="plain" systemItem="flexibleSpace" id="NdI-tc-oN0"/>
+                        <barButtonItem style="plain" systemItem="flexibleSpace" id="Rxy-Fo-qMI"/>
+                    </toolbarItems>
+                    <navigationItem key="navigationItem" id="mK0-v7-fPK"/>
+                    <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="RBq-ms-PJd" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
@@ -199,16 +122,35 @@
                         </connections>
                     </tableView>
                     <toolbarItems/>
+                    <navigationItem key="navigationItem" id="4ca-r1-O8B"/>
                     <nil key="simulatedBottomBarMetrics"/>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="piq-2F-sld" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="2579" y="350"/>
         </scene>
+        <!--Files View Controller-->
+        <scene sceneID="KL3-rw-eaR">
+            <objects>
+                <viewController id="TtK-ae-EWl" customClass="FilesViewController" customModule="MiniKeePass" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="QWF-sv-Eth"/>
+                        <viewControllerLayoutGuide type="bottom" id="ex8-uP-oQ9"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="gBQ-25-raq">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkQ-aE-CQn" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="238" y="349"/>
+        </scene>
         <!--Navigation Controller-->
         <scene sceneID="DAx-kx-5iF">
             <objects>
-                <navigationController toolbarHidden="NO" id="APd-hG-9Gf" sceneMemberID="viewController">
+                <navigationController storyboardIdentifier="OpenDatabase" toolbarHidden="NO" id="APd-hG-9Gf" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="waS-9H-vbV">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
@@ -220,16 +162,15 @@
                         <autoresizingMask key="autoresizingMask"/>
                     </toolbar>
                     <connections>
-                        <segue destination="gkV-37-I3l" kind="relationship" relationship="rootViewController" id="TpE-FJ-EWZ"/>
+                        <segue destination="I0k-i1-GRC" kind="relationship" relationship="rootViewController" id="c29-Nq-HME"/>
                     </connections>
                 </navigationController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="3Lf-dS-6oa" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="392.5" y="350.5"/>
+            <point key="canvasLocation" x="1154" y="349"/>
         </scene>
     </scenes>
     <resources>
         <image name="gear" width="24" height="24"/>
-        <image name="help" width="24" height="24"/>
     </resources>
 </document>

--- a/MiniKeePass/New Database View/NewDatabase.storyboard
+++ b/MiniKeePass/New Database View/NewDatabase.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="sHd-VR-6rV">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="sHd-VR-6rV">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
@@ -152,6 +152,7 @@
         <!--Navigation Controller-->
         <scene sceneID="xoJ-sG-eF5">
             <objects>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Y9d-69-uT8" userLabel="First Responder" sceneMemberID="firstResponder"/>
                 <navigationController id="sHd-VR-6rV" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="1hw-9i-uGE">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
@@ -161,7 +162,6 @@
                         <segue destination="F1U-jU-Mc4" kind="relationship" relationship="rootViewController" id="ysd-gH-N2f"/>
                     </connections>
                 </navigationController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="Y9d-69-uT8" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-739" y="264"/>
         </scene>

--- a/MiniKeePass/New Database View/NewDatabaseViewController.swift
+++ b/MiniKeePass/New Database View/NewDatabaseViewController.swift
@@ -16,7 +16,7 @@
  */
 
 protocol NewDatabaseDelegate {
-    func newDatabaseCreated(filename: String)
+    func newDatabaseCreated(url: URL?)
 }
 
 class NewDatabaseViewController: UITableViewController, UITextFieldDelegate {
@@ -100,12 +100,13 @@ class NewDatabaseViewController: UITableViewController, UITextFieldDelegate {
         let databaseManager = DatabaseManager.sharedInstance()
         databaseManager?.newDatabase(url, password: password1, version: version)
         
-        delegate?.newDatabaseCreated(filename: url!.lastPathComponent)
+        delegate?.newDatabaseCreated(url: url)
         
         dismiss(animated: true, completion: nil)
     }
     
     @IBAction func cancelPressed(_ sender: UIBarButtonItem) {
+        delegate?.newDatabaseCreated(url: nil)
         dismiss(animated: true, completion: nil)
     }
 }

--- a/MiniKeePass/Password Entry View/PasswordEntry.storyboard
+++ b/MiniKeePass/Password Entry View/PasswordEntry.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="rxu-he-bvs">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="rxu-he-bvs">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
@@ -80,9 +80,6 @@
                                                 <constraint firstItem="4nL-La-6er" firstAttribute="trailing" secondItem="iB9-jB-ZXZ" secondAttribute="trailingMargin" id="xrb-ui-vJu"/>
                                             </constraints>
                                         </tableViewCellContentView>
-                                        <connections>
-                                            <segue destination="ImN-Rw-SFR" kind="show" id="697-yO-1Aa"/>
-                                        </connections>
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
@@ -138,6 +135,7 @@
         <!--Key File-->
         <scene sceneID="esE-mw-wQX">
             <objects>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="BqO-gl-weO" userLabel="First Responder" sceneMemberID="firstResponder"/>
                 <tableViewController id="ImN-Rw-SFR" customClass="KeyFileViewController" customModule="MiniKeePass" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" alwaysBounceHorizontal="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="nw4-nD-SH0">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
@@ -160,7 +158,6 @@
                     </tableView>
                     <navigationItem key="navigationItem" title="Key File" id="UOO-cR-GQD"/>
                 </tableViewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="BqO-gl-weO" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="544" y="253"/>
         </scene>


### PR DESCRIPTION
Use the new (-ish) APIs introduced in iOS 11. These include changing the `FilesViewController` to a `UIDocumentBrowserController` subclass, eliminating the `KeyFileViewController` in favor of a generic `UIDocumentPickerViewController`. This then enables "open in place" so that it is no longer necessary to copy the db and key files into the app directly.

Other than the ViewController changes, another big change is the conversion of paths (aka `String`/`NSString`) to `URL`s